### PR TITLE
Fix checking if livereload option has been set

### DIFF
--- a/lib/index.cjs.js
+++ b/lib/index.cjs.js
@@ -219,7 +219,7 @@ function DevServer(opts) {
 	this.livereload = createLiveReloadOptions(opts.livereload);
 
 	let livereloadMiddleware = null;
-	if (livereload$1) {
+	if (this.livereload) {
 		const _opts = { host: this.host, protocol: this.protocol, errorProvider: this };
 		const src = this.livereload.src;
 		const port = this.livereload.port;

--- a/lib/index.esm.js
+++ b/lib/index.esm.js
@@ -215,7 +215,7 @@ function DevServer(opts) {
 	this.livereload = createLiveReloadOptions(opts.livereload);
 
 	let livereloadMiddleware = null;
-	if (livereload$1) {
+	if (this.livereload) {
 		const _opts = { host: this.host, protocol: this.protocol, errorProvider: this };
 		const src = this.livereload.src;
 		const port = this.livereload.port;

--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ function DevServer(opts) {
 	this.livereload = createLiveReloadOptions(opts.livereload);
 
 	let livereloadMiddleware = null;
-	if (livereload) {
+	if (this.livereload) {
 		const _opts = { host: this.host, protocol: this.protocol, errorProvider: this };
 		const src = this.livereload.src;
 		const port = this.livereload.port;


### PR DESCRIPTION
Commit fd74513 removed the `this.` before the check for the livereload member, although that is the one that is set just a couple of lines above. I believe this must have been an editing error, because now the server dies with an error if the livereload options is not set.